### PR TITLE
Add selectable modes with default MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - Reasoning model support.
 - [shadcn/ui](https://ui.shadcn.com/) components for a modern, responsive UI powered by [Tailwind CSS](https://tailwindcss.com).
 - Built with the latest [Next.js](https://nextjs.org) App Router.
+- Mode system with preconfigured MCP servers for common workflows.
 
 ## MCP Server Configuration
 

--- a/components/chat-sidebar.tsx
+++ b/components/chat-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter, usePathname } from "next/navigation";
-import { MessageSquare, PlusCircle, Trash2, ServerIcon, Settings, Sparkles, ChevronsUpDown, Copy, Pencil, Github, Key } from "lucide-react";
+import { MessageSquare, PlusCircle, Trash2, ServerIcon, Settings, Sparkles, ChevronsUpDown, Copy, Pencil, Github, Key, Briefcase } from "lucide-react";
 import {
     Sidebar,
     SidebarContent,
@@ -25,6 +25,7 @@ import Image from "next/image";
 import { MCPServerManager } from "./mcp-server-manager";
 import { ApiKeyManager } from "./api-key-manager";
 import { ThemeToggle } from "./theme-toggle";
+import { ModePicker } from "./mode-picker";
 import { getUserId, updateUserId } from "@/lib/user-id";
 import { useChats } from "@/lib/hooks/use-chats";
 import { cn } from "@/lib/utils";
@@ -399,6 +400,15 @@ export function ChatSidebar() {
                                 }}>
                                     <Github className="mr-2 h-4 w-4 hover:text-sidebar-accent" />
                                     GitHub
+                                </DropdownMenuItem>
+                                <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                                    <div className="flex items-center justify-between w-full">
+                                        <div className="flex items-center">
+                                            <Briefcase className="mr-2 h-4 w-4 hover:text-sidebar-accent" />
+                                            Mode
+                                        </div>
+                                        <ModePicker className="h-6" />
+                                    </div>
                                 </DropdownMenuItem>
                                 <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
                                     <div className="flex items-center justify-between w-full">

--- a/components/mode-picker.tsx
+++ b/components/mode-picker.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "./ui/select";
+import { useMCP } from "@/lib/context/mcp-context";
+import { MODES } from "@/lib/modes";
+import { cn } from "@/lib/utils";
+
+export function ModePicker({ className }: { className?: string }) {
+  const { mode, setMode } = useMCP();
+
+  return (
+    <Select value={mode} onValueChange={setMode}>
+      <SelectTrigger className={cn("h-6 w-24", className)}>
+        <SelectValue placeholder="Mode" />
+      </SelectTrigger>
+      <SelectContent>
+        {MODES.map(m => (
+          <SelectItem key={m.id} value={m.id}>
+            {m.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -6,5 +6,6 @@
 export const STORAGE_KEYS = {
   MCP_SERVERS: "mcp-servers",
   SELECTED_MCP_SERVERS: "selected-mcp-servers",
-  SIDEBAR_STATE: "sidebar-state"
-}; 
+  SIDEBAR_STATE: "sidebar-state",
+  MODE: "app-mode"
+};

--- a/lib/modes.ts
+++ b/lib/modes.ts
@@ -1,0 +1,54 @@
+export interface ModeServer {
+  name: string;
+  url: string;
+  type: 'sse' | 'stdio';
+  command?: string;
+  args?: string[];
+  env?: { key: string; value: string }[];
+  headers?: { key: string; value: string }[];
+  description?: string;
+}
+
+export interface Mode {
+  id: string;
+  name: string;
+  defaultServers: ModeServer[];
+}
+
+export const MODES: Mode[] = [
+  {
+    id: 'default',
+    name: 'Default',
+    defaultServers: []
+  },
+  {
+    id: 'work',
+    name: 'Work',
+    defaultServers: [
+      {
+        name: 'Google Drive MCP',
+        url: 'https://mcp.example.com/google-drive/sse',
+        type: 'sse',
+        description: 'Access Google Drive tools'
+      },
+      {
+        name: 'Gmail MCP',
+        url: 'https://mcp.example.com/gmail/sse',
+        type: 'sse',
+        description: 'Access Gmail tools'
+      }
+    ]
+  },
+  {
+    id: 'research',
+    name: 'Research',
+    defaultServers: [
+      {
+        name: 'Research MCP',
+        url: 'https://mcp.example.com/research/sse',
+        type: 'sse',
+        description: 'Research utilities'
+      }
+    ]
+  }
+];


### PR DESCRIPTION
## Summary
- introduce new `MODES` configuration describing default MCP servers for different modes
- store selected mode in local storage via `MODE` key
- update MCP context to manage a mode and load default servers accordingly
- add `ModePicker` component and expose it in the sidebar menu
- document mode support in README

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ae1b70f44832eac9662f14c3a35f2